### PR TITLE
Modify borges to fetch only HEAD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,26 @@
-FROM alpine:3.6
+#================================
+# Stage 1: Build borges
+#================================
+FROM golang:1.12-alpine as builder
+MAINTAINER dpordomingo
+
+ENV REPO=${GOPATH}/src/github.com/src-d/borges
+
+# RUN apk add --update --no-cache libxml2-dev git make bash gcc g++ curl oniguruma-dev oniguruma
+RUN apk add --update --no-cache make bash git curl
+
+COPY . ${REPO}
+WORKDIR ${REPO}
+
+RUN make build
+
+#=================================
+# Stage 2: Start borges
+#=================================
+FROM alpine:3.8
 MAINTAINER source{d}
+
+ENV REPO=/go/src/github.com/src-d/borges
 
 ENV BORGES_DATABASE=postgres://testing:testing@postgres/testing?application_name=borges&sslmode=disable&connect_timeout=30
 ENV BORGES_BROKER=amqp://guest:guest@rabbitmq:5672/
@@ -7,9 +28,9 @@ ENV BORGES_ROOT_REPOSITORIES_DIR=/var/root-repositories
 
 RUN mkdir -p /var/root-repositories
 
-RUN apk add --no-cache ca-certificates dumb-init=1.2.0-r0 git
+RUN apk add --no-cache ca-certificates dumb-init=1.2.1-r0 git
 
-ADD build/borges_linux_amd64/borges /bin/
+COPY --from=builder ${REPO}/build/borges_linux_amd64/borges /bin/
 
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 CMD ["borges"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,41 @@
+version: '3.3'
+
+services:
+  postgres:
+    image: "postgres:9.6-alpine"
+    restart: always
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_PASSWORD: testing
+      POSTGRES_USER: testing
+  rabbitmq:
+    image: "rabbitmq:3-management"
+    restart: always
+    ports:
+      - "15672:15672"
+      - "5672:5672"
+  consumer:
+    image: srcd/borges:dev
+    build: .
+    depends_on:
+      - postgres
+      - rabbitmq
+    links:
+      - "rabbitmq:rabbitmq"
+      - "postgres:postgres"
+    entrypoint: ["/bin/sh"]
+    command: ["-c", "sleep ${BORGES_DELAY:-10} && borges init && borges consumer --workers=${WORKERS:-1} --bucket-size=${BUCKET_SIZE:-2}"]
+    volumes:
+      - ${SIVA_ROOT_PATH:?'SIVA_ROOT_PATH'; siva root absolute path is missing}:/var/root-repositories
+  producer:
+    image: srcd/borges:dev
+    depends_on:
+      - consumer
+    links:
+      - "rabbitmq:rabbitmq"
+      - "postgres:postgres"
+    entrypoint: ["/bin/sh"]
+    command: ["-c", "sleep ${BORGES_DELAY:-10} && borges producer file /opt/borges/repos.txt"]
+    volumes:
+      - ${REPOS_TXT_PATH:?'REPOS_TXT_PATH'; 'repos.txt' absolute path is missing}:/opt/borges/repos.txt

--- a/git.go
+++ b/git.go
@@ -294,7 +294,7 @@ func (b *temporaryRepositoryBuilder) Clone(
 	}
 
 	o := &git.FetchOptions{
-		RefSpecs: []config.RefSpec{FetchRefSpec, FetchHEAD},
+		RefSpecs: []config.RefSpec{ /*FetchRefSpec,*/ FetchHEAD},
 		Force:    true,
 	}
 	err = remote.FetchContext(ctx, o)


### PR DESCRIPTION
With this PR it is provide a new configuration for borges:
- downloads only `HEAD`,
- can be run with `docker-compose`.

To run it, you only need to run
```shell
WORKDIR=$(pwd)
OUTPUT=${WORKDIR}/pga/repos
OUTPUT_LOG=${WORKDIR}/repos.out.log
REPOS_TXT_PATH=${WORKDIR}/repos.txt;
WORKERS=12;
BUCKET_SIZE=2;
SIVA_ROOT_PATH=${OUTPUT};
export SIVA_ROOT_PATH;
export REPOS_TXT_PATH;
export WORKERS;
export BUCKET_SIZE;
docker-compose down && \
docker rmi -f srcd/borges:dev && \
docker-compose up 2>&1 | tee ${OUTPUT_LOG}
```

making sure that the list of repos to fetch is properly pointed by `${WORKDIR}/repos.txt;`